### PR TITLE
Fix typo, change name to 'vivian', from 'vivan'

### DIFF
--- a/syntaxes/vivian.tmLanguage.json
+++ b/syntaxes/vivian.tmLanguage.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
-    "name": "vivan",
+    "name": "vivian",
     "patterns": [{
             "include": "#keywords"
         },


### PR DESCRIPTION
Fix typo in language name;

before:

> ```json
> "name": "vivan"
> ```

after:
> ```json
> "name": "vivian"
> ```